### PR TITLE
Uses the unversioned library

### DIFF
--- a/k2hdkc/k2hdkc.go
+++ b/k2hdkc/k2hdkc.go
@@ -23,7 +23,7 @@ package k2hdkc
 #include <stdio.h>
 static int dlopen_k2hdkc() {
   dlerror();
-  void* handler = dlopen("libk2hdkc.so.0", RTLD_LAZY);
+  void* handler = dlopen("libk2hdkc.so", RTLD_LAZY);
   if (handler == NULL) {
     char* error = dlerror();
     if (error != NULL) {


### PR DESCRIPTION
#### Relevant Issue (if applicable)
 N/A

#### Details
This PR make k2hdkc_go use the unversioned k2hdkc library instead of the versioned one.
